### PR TITLE
Moving database packages out of Flatcar

### DIFF
--- a/lib/flatcar/models/webapp_service.rb
+++ b/lib/flatcar/models/webapp_service.rb
@@ -45,9 +45,9 @@ module Flatcar
     def base_image_instruction
       case @base_image
       when 'alpine'
-        instruction = ['FROM centurylink/alpine-rails']
-        instruction << alpine_database_packages if @database
-        instruction.join("\n")
+        [
+          'FROM centurylink/alpine-rails'
+        ].join("\n")
       when 'ubuntu'
         [
           'FROM centurylink/ubuntu-rails'
@@ -58,17 +58,6 @@ module Flatcar
           'RUN apt-get update && apt-get install -y nodejs --no-install-recommends && rm -rf /var/lib/apt/lists/*',
           'RUN apt-get update && apt-get install -y mysql-client postgresql-client sqlite3 --no-install-recommends && rm -rf /var/lib/apt/lists/*'
         ].join("\n")
-      end
-    end
-
-    def alpine_database_packages
-      case @database.name
-      when 'postgresql'
-        'RUN apk --update add libpq postgresql-dev'
-      when 'mysql'
-        'RUN apk --update add mysql-dev'
-      else
-        return
       end
     end
   end

--- a/spec/flatcar/models/webapp_service_spec.rb
+++ b/spec/flatcar/models/webapp_service_spec.rb
@@ -52,8 +52,7 @@ describe Flatcar::WebappService do
 
         it 'includes the alpine base image instructions with the postgres libraries' do
           expect(subject.dockerfile).to eq([
-                                             'FROM centurylink/alpine-rails',
-                                             'RUN apk --update add libpq postgresql-dev',
+                                             'FROM centurylink/alpine-rails'
                                            ].push(common_lines).join("\n"))
         end
       end
@@ -65,8 +64,7 @@ describe Flatcar::WebappService do
 
         it 'includes the alpine base image instructions with the mysql libraries' do
           expect(subject.dockerfile).to eq([
-                                             'FROM centurylink/alpine-rails',
-                                             'RUN apk --update add mysql-dev',
+                                             'FROM centurylink/alpine-rails'
                                            ].push(common_lines).join("\n"))
         end
       end


### PR DESCRIPTION
Instead of adding databast dev packages in Flatcar, I moved them all to the Alpine base image so that it works better as a standalone base-image
